### PR TITLE
Fix QML warning

### DIFF
--- a/mobile/FrontPage.qml
+++ b/mobile/FrontPage.qml
@@ -12,7 +12,7 @@ ColumnLayout {
 
     Connections {
         target: uploader
-        onSuccess: {
+        function onSuccess(url) {
             console.warn("FINISHED")
             console.warn(url)
             inputField.text += " "
@@ -20,7 +20,7 @@ ColumnLayout {
             inputField.text += " "
             imageButton.isBusy = false
         }
-        onError: {
+        function onError(message) {
             console.warn("ERROR")
             console.warn(message)
             imageButton.isBusy = false


### PR DESCRIPTION
qrc:/FrontPage.qml:13:5: QML Connections: Implicitly defined onFoo
properties in Connections are deprecated. Use this syntax instead:
function onFoo(<arguments>) { ... }