### PR TITLE
Improve URL shortening

### DIFF
--- a/datamodel.cpp
+++ b/datamodel.cpp
@@ -766,8 +766,10 @@ BufferLineSegment::BufferLineSegment(BufferLine *parent, const QString &text, Bu
         QString extension = url.fileName().split(".").last().toLower();
         QString host = url.host();
         QString file = url.fileName();
-        if (!file.isEmpty() && !host.isEmpty() && !extension.isEmpty())
-            m_summary = url.host() + "-" + url.fileName();
+        const auto maxUnshortenedLinkLength = 50;
+        if (plainTextGet().size() > maxUnshortenedLinkLength && !file.isEmpty() && !host.isEmpty() && !extension.isEmpty())
+            // \u2026 is the ellipsis character
+            m_summary = url.scheme() + "://" + host + "/\u2026/" + file;
         else
             m_summary = plainTextGet();
         if (QStringList{"png", "jpg", "gif"}.indexOf(extension) != -1)


### PR DESCRIPTION
AHOJ není to ideální, ale je to lepší než předtim
- Only shorten if the URL is longer than 50 characters.
- Include the URL scheme: makes it more recognizable as a link,
especially when there are unshortened links.
- Change dash to an ellipsis.