### PR TITLE
Get shortnames from relay so the bufferlist names look better

### DIFF
--- a/src/datamodel.h
+++ b/src/datamodel.h
@@ -37,6 +37,7 @@ class Buffer : public QObject {
     Q_OBJECT
     PROPERTY(int, number)
     PROPERTY(QString, name)
+    PROPERTY(QString, short_name)
     ALIAS(QString, name, full_name)
     PROPERTY(QString, title)
     PROPERTY(QStringList, local_variables)

--- a/ui/BufferList.qml
+++ b/ui/BufferList.qml
@@ -127,7 +127,7 @@ Drawer {
                             id: bufferName
                             Layout.fillWidth: true
                             clip: true
-                            text: buffer.name.split(".").slice(-1)[0]
+                            text: buffer.short_name === "" ? buffer.name : buffer.short_name
                             font.family: "Menlo"
                             font.pointSize: settings.baseFontSize * 1.125
                             color: palette.windowText


### PR DESCRIPTION
Fixes stuff like channel #test.cz being shown as "cz".

I know the connection is gonna be rewritten a/w, but please get short_name from buffer:gui_buffers in the rewrite as well, kthnx)))))
