### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/uploader.cpp
+++ b/src/uploader.cpp
@@ -36,10 +36,10 @@ void Uploader::upload(const QString &path) {
         }
         QImage im(QUrl(path).toLocalFile());
         if (transformation & QImageIOHandler::TransformationRotate90) {
-            QMatrix matrix;
-            matrix.translate(im.size().width() / 2, im.size().height() / 2);
-            matrix.rotate(90);
-            im = im.transformed(matrix);
+            QTransform transform;
+            transform.translate(im.size().width() / 2, im.size().height() / 2);
+            transform.rotate(90);
+            im = im.transformed(transform);
         }
         uploadBinary(im);
         return;


### PR DESCRIPTION
```
../src/uploader.cpp: In member function ‘void Uploader::upload(const QString&)’:
../src/uploader.cpp:42:39: warning: ‘QImage QImage::transformed(const QMatrix&, Qt::TransformationMode) const’ is deprecated: Use transformed(const QTransform &matrix, Qt::TransformationMode mode) [-Wdeprecated-declarations]
   42 |             im = im.transformed(matrix);
```