### PR TITLE
Fixed errormsg not disappearing when previewing an image after an err…

### DIFF
--- a/ui/PreviewPopup.qml
+++ b/ui/PreviewPopup.qml
@@ -42,6 +42,7 @@ Dialog {
         delegateImage.source = url
         imageWrapper.visible = true
         videoWrapper.visible = false
+        errorMsgText.visible = delegateImage.status === Image.Error
         root.open()
     }
     function showVideo(url) {
@@ -51,6 +52,7 @@ Dialog {
         delegateVideo.volume = lith.settings.muteVideosByDefault ? 0.0 : 1.0
         videoWrapper.visible = true
         imageWrapper.visible = false
+        errorMsgText.visible = delegateVideo.errorString.length > 0
         root.open()
     }
     onVisibleChanged: {
@@ -75,6 +77,9 @@ Dialog {
             width: parent.width - 2
             height: parent.height - 2
             anchors.centerIn: parent
+            onErrorChanged: {
+                errorMsgText.visible = delegateVideo.errorString.length > 0
+            }
         }
         BusyIndicator {
             anchors.centerIn: parent
@@ -194,6 +199,9 @@ Dialog {
                 rotation = 0
                 scale = 1
             }
+            onStatusChanged: {
+                errorMsgText.visible = delegateImage.status === Image.Error
+            }
 
             fillMode: Image.PreserveAspectFit
             width: parent.width - 2
@@ -296,8 +304,9 @@ Dialog {
             }
             spacing: 12
             Text {
+                id: errorMsgText
+                // visible: delegateImage.status === Image.Error || delegateVideo.errorString.length > 0
                 Layout.alignment: Qt.AlignHCenter
-                visible: delegateImage.status === Image.Error || delegateVideo.errorString.length > 0
                 color: "red"
                 text: delegateImage.status === Image.Error ? qsTr("The picture could not be displayed") : delegateVideo.errorString
             }

--- a/ui/PreviewPopup.qml
+++ b/ui/PreviewPopup.qml
@@ -42,7 +42,6 @@ Dialog {
         delegateImage.source = url
         imageWrapper.visible = true
         videoWrapper.visible = false
-        errorMsgText.visible = delegateImage.status === Image.Error
         root.open()
     }
     function showVideo(url) {
@@ -52,13 +51,14 @@ Dialog {
         delegateVideo.volume = lith.settings.muteVideosByDefault ? 0.0 : 1.0
         videoWrapper.visible = true
         imageWrapper.visible = false
-        errorMsgText.visible = delegateVideo.errorString.length > 0
         root.open()
     }
     onVisibleChanged: {
         if (!visible) {
             currentUrl = ""
             delegateVideo.stop()
+            delegateVideo.source = ""
+            delegateImage.source = ""
         }
     }
 
@@ -77,9 +77,6 @@ Dialog {
             width: parent.width - 2
             height: parent.height - 2
             anchors.centerIn: parent
-            onErrorChanged: {
-                errorMsgText.visible = delegateVideo.errorString.length > 0
-            }
         }
         BusyIndicator {
             anchors.centerIn: parent
@@ -305,7 +302,7 @@ Dialog {
             spacing: 12
             Text {
                 id: errorMsgText
-                // visible: delegateImage.status === Image.Error || delegateVideo.errorString.length > 0
+                visible: delegateImage.status === Image.Error || delegateVideo.errorString.length > 0
                 Layout.alignment: Qt.AlignHCenter
                 color: "red"
                 text: delegateImage.status === Image.Error ? qsTr("The picture could not be displayed") : delegateVideo.errorString

--- a/ui/PreviewPopup.qml
+++ b/ui/PreviewPopup.qml
@@ -196,9 +196,6 @@ Dialog {
                 rotation = 0
                 scale = 1
             }
-            onStatusChanged: {
-                errorMsgText.visible = delegateImage.status === Image.Error
-            }
 
             fillMode: Image.PreserveAspectFit
             width: parent.width - 2


### PR DESCRIPTION
…ornous video file and the other way around, ofc.

And yes, the visibiltiy is needed both in showImage/showVideo AND in onStatusChanged / onErrorChanged otherwise this isn't fixed fully

**Motivation**:
* If it's only in **onStatusChanged** / **onErrorChanged** the error message won't get cleared when previewing an image AFTER an errornous video file (e.g. "Not found").
* If it's only in showImage / showVideo the error message won't appear at all.

**Before:**
![before](https://user-images.githubusercontent.com/5108747/99317906-12f94280-2867-11eb-8f8a-c3d98fcf037e.gif)

**After:** 
![after](https://user-images.githubusercontent.com/5108747/99317911-155b9c80-2867-11eb-93d3-bb82f70f8de3.gif)
