### PR TITLE
iOS: POC: Added option to open webm files in iOS VLC app

### DIFF
--- a/dist/ios/Info.plist
+++ b/dist/ios/Info.plist
@@ -7,11 +7,9 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
 	<string>${PRODUCT_NAME}</string>
-        <key>CFBundleVersion</key>
-        <string>${QMAKE_FULL_VERSION}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -19,7 +17,13 @@
 	<key>CFBundleSignature</key>
 	<string>${QMAKE_PKGINFO_TYPEINFO}</string>
 	<key>CFBundleVersion</key>
-        <string>${QMAKE_FULL_VERSION}</string>
+	<string>${QMAKE_FULL_VERSION}</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>vlc</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
@@ -31,9 +35,7 @@
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Used to upload photos to the chat</string>
 	<key>UILaunchStoryboardName</key>
-        <string>LaunchScreen</string>
-        <key>ITSAppUsesNonExemptEncryption</key>
-        <false/>
+	<string>LaunchScreen</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/src/settings.h
+++ b/src/settings.h
@@ -64,6 +64,7 @@ class Settings : public QObject {
 
     SETTING(bool, openLinksDirectly, false)
     SETTING(bool, openLinksDirectlyInBrowser, false)
+    SETTING(bool, openWebmsInVlc, false)
 
     SETTING(QString, host)
     SETTING(int, port, 9001)

--- a/ui/MainView.qml
+++ b/ui/MainView.qml
@@ -161,6 +161,11 @@ Item {
         function openCurrentLink(openPreview) {
             if (linkHandler.containsImage && openPreview)
                 previewPopup.showImage(linkHandler.currentLink)
+            else if (linkHandler.containsVideo
+                     && linkHandler.currentExtension.endsWith("webm")
+                     && Qt.platform.os === "ios"
+                     && settings.openWebmsInVlc)
+                Qt.openUrlExternally("vlc://" + linkHandler.currentLink)
             else if (linkHandler.containsVideo && openPreview)
                 previewPopup.showVideo(linkHandler.currentLink)
             else

--- a/ui/SettingsInterface.qml
+++ b/ui/SettingsInterface.qml
@@ -39,6 +39,7 @@ ScrollView {
         settings.forceLightTheme = forceLightThemeCheckbox.checked
         settings.forceDarkTheme = forceDarkThemeCheckbox.checked
         settings.useTrueBlackWithDarkTheme = useTrueBlackWithDarkThemeCheckbox.checked
+        settings.openWebmsInVlc = openWebmsInVlcCheckbox.checked
     }
     function onRejected() {
         shortenLongUrlsCheckbox.checked = settings.shortenLongUrls
@@ -56,6 +57,7 @@ ScrollView {
         forceLightThemeCheckbox.checked = settings.forceLightTheme
         forceDarkThemeCheckbox.checked = settings.forceDarkTheme
         useTrueBlackWithDarkThemeCheckbox.checked = settings.useTrueBlackWithDarkTheme
+        openWebmsInVlcCheckbox.checked = settings.openWebmsInVlc
     }
 
     ColumnLayout {
@@ -277,6 +279,18 @@ ScrollView {
                     text: qsTr("In browser")
                     color: openLinksDirectlyInBrowserSwitch.checked ? palette.text : disabledPalette.text
                 }
+            }
+
+            Label {
+                visible: Qt.platform.os === "ios"
+                Layout.alignment: Qt.AlignRight
+                text: qsTr("Attempt to open webm files in VLC")
+            }
+            CheckBox {
+                visible: Qt.platform.os === "ios"
+                id: openWebmsInVlcCheckbox
+                checked: settings.openWebmsInVlc
+                Layout.alignment: Qt.AlignLeft
             }
 
             Label {


### PR DESCRIPTION
Hello.

This is a very simple PoC enabling opening webm in the iOS VLC application when it's installed and therefore enabling at least somewhat of a good user experience with webms sent to the user on IRC if he's willing to use VLC on his device.

Link to VLC for Mobile: https://apps.apple.com/us/app/vlc-for-mobile/id650377962

**Pros:**
This adds option "Attempt to open webms in VLC" to the Settings dialog only when the platform is iOS, otherwise the setting is set to false and not rendered in the Settings dialog.

When this **setting is enabled:**
* If the user is using Directly open links -> it will prepend "vlc://" to the link and open the link using Qt.openUrlExternally()
* If the user is using the link popup window with actions (open in browser/preview) the preview & open in browser buttons BOTH do the same thing and again, prepend "vlc://" the URL & open Qt.openUrlExternally() -- this is the only thing that is probably nonsensical and the "Open in browser" button should maybe _actually_ open the browser?
* Note: If the user never opened a vlc:// link from Lith before, he will get a dialog about "Lith wants to open VLC", tested on iOS 13.7, 14 and up might have different behavior/dialog, cannot test that.

Before & after behavior can be seen on this video:
https://user-images.githubusercontent.com/5108747/106830915-4477f200-668f-11eb-860d-5db94275aac7.mp4

**Cons:**
- As of right now (and probably no way around it), if the user doesn't have VLC installed, enabling this option right now will result in **no operation** (aka link won't be opened at all since there's no app that would open the vlc:// scheme). Should maybe warn the user when he sets the option to true that "he makes sure he actually has VLC installed otherwise webms won't be opening"?
- Additional Info.plist permission needed so that the app can call the vlc:// scheme link. This poses a potential "rejection on  AppStore by Apple" problem, since it's vlc:// and not stuff like instagram://, who knows what's their stance on this stuff. 

Suggestions, discussion, opinions welcome :)
BTW: If iOS 14 somehow "fixes" this and you can somehow associate .webms in Safari to directly open in an app, then this may be useless and I apologize, but on iOS 13.7 that I'm running the only option after opening in Safari (or any other browser) is to "Download" and open in VLC manually or "Share" to VLC which downloads it and opens it in VLC instead of streaming it.