### PR TITLE
Fixed smalltext in SettingsNetwork

### DIFF
--- a/ui/SettingsNetwork.qml
+++ b/ui/SettingsNetwork.qml
@@ -100,7 +100,7 @@ ScrollView {
                 }
                 Label {
                     text: "(More secure, available since WeeChat 2.9)"
-                    font.pointSize: settings.baseFontSize * 0.75
+                    font.pointSize: font.pointSize * 0.75
                 }
             }
             CheckBox {


### PR DESCRIPTION
This was forgotten there since the font size in the settings dialog is no longer changed based on the "Message font size" set in the Interface tab.
 
Before:
![image](https://user-images.githubusercontent.com/5108747/117118913-a67cec00-ad91-11eb-95c5-622b87724e92.png)

After:
![image](https://user-images.githubusercontent.com/5108747/117118939-b1d01780-ad91-11eb-9c44-ef9e462411f8.png)
