### PR TITLE
mix() takes a float argument, not double

### DIFF
--- a/src/util/colortheme.cpp
+++ b/src/util/colortheme.cpp
@@ -28,8 +28,8 @@ QPalette ColorTheme::palette() const {
     // TODO very likely needs a bit of tweaking to differentiate button, window and base
     QColor windowText { m_weechatColors[0] };
     QColor button { m_weechatColors[1] };
-    QColor light = mix(windowText, button, 0.4);
-    QColor dark = mix(button, windowText, 0.4);
+    QColor light = mix(windowText, button, 0.4f);
+    QColor dark = mix(button, windowText, 0.4f);
     QColor mid = mix(light, dark);
     QColor text = windowText;
     QColor bright_text = text;


### PR DESCRIPTION
```
..\src\util\colortheme.cpp(31): warning C4305: 'argument': truncation from 'double' to 'float'
..\src\util\colortheme.cpp(32): warning C4305: 'argument': truncation from 'double' to 'float'
```