### PR TITLE
Send newlines in messages as new inputs

### DIFF
--- a/src/datamodel.cpp
+++ b/src/datamodel.cpp
@@ -187,8 +187,15 @@ bool Buffer::isPrivateGet() const {
 bool Buffer::input(const QString &data) {
     if (Lith::instance()->statusGet() == Lith::CONNECTED) {
         bool success = false;
-        QMetaObject::invokeMethod(Lith::instance()->weechat(), "input", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, success), Q_ARG(pointer_t, m_ptr), Q_ARG(QString, data));
-        return success;
+        QList<bool> success_list;
+
+        auto data_split = data.split(QRegularExpression("\n|\r\n|\r"));
+
+        for (auto &data_single_line : data_split) {
+            QMetaObject::invokeMethod(Lith::instance()->weechat(), "input", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, success), Q_ARG(pointer_t, m_ptr), Q_ARG(QString, data_single_line));
+            success_list.append(success);
+        }
+        return !success_list.contains(false);
     }
     return false;
     //Lith::instance()->weechat()->input(m_ptr, data);


### PR DESCRIPTION
@MartinBriza won't like this, but this is what peak performance looks like.

No UI changes have been made, so no indication of the user sending a newline is shown, just like it was before this PR, aka it just shows as empty char i.e.:
```
"test1
test2"
```

still appears as `"test1test2"` in the Input bar, see GIF:
![lal](https://user-images.githubusercontent.com/5108747/136064783-531b8166-9163-43be-b8df-81329f58cedd.gif)





* This could also be implemented in QML (in OnAccept/SendButton press)
* This could also be implemented as a newline char replacement (since sending a too long of a message already splits correctly, see screenshot):
![image](https://user-images.githubusercontent.com/5108747/136064371-ca864f40-9351-43af-a90b-1aa6de5d0dfe.png)

