### PR TITLE
Use QSortFilterProxy for toggling join/quit messages

### DIFF
--- a/Lith.pro
+++ b/Lith.pro
@@ -16,6 +16,7 @@ HEADERS += \
     src/settings.h \
     src/uploader.h \
     src/util/formattedstring.h \
+    src/util/messagelistfilter.h \
     src/util/nicklistfilter.h \
     src/weechat.h \
     src/common.h \
@@ -33,6 +34,7 @@ SOURCES += \
     src/settings.cpp \
     src/uploader.cpp \
     src/util/formattedstring.cpp \
+    src/util/messagelistfilter.cpp \
     src/util/nicklistfilter.cpp \
     src/weechat.cpp \
     src/windowhelper.cpp \

--- a/src/datamodel.cpp
+++ b/src/datamodel.cpp
@@ -32,6 +32,7 @@ Buffer::Buffer(Lith *parent, pointer_t pointer)
     : QObject(parent)
     , m_lines(QmlObjectList::create<BufferLine>(this))
     , m_nicks(QmlObjectList::create<Nick>(this))
+    , m_proxyLinesFiltered(new MessageFilterList(this, m_lines))
     , m_ptr(pointer)
 {
 
@@ -182,6 +183,10 @@ bool Buffer::isChannelGet() const {
 
 bool Buffer::isPrivateGet() const {
     return m_local_variables.contains("type") && m_local_variables["type"] == "private";
+}
+
+MessageFilterList *Buffer::lines_filtered() {
+    return m_proxyLinesFiltered;
 }
 
 bool Buffer::input(const QString &data) {

--- a/src/datamodel.h
+++ b/src/datamodel.h
@@ -21,6 +21,7 @@
 #include "common.h"
 #include "qmlobjectlist.h"
 #include "protocol.h"
+#include "util/messagelistfilter.h"
 
 #include <QObject>
 #include <QDateTime>
@@ -65,6 +66,7 @@ class Buffer : public QObject {
     PROPERTY(int, unreadMessages)
     PROPERTY(int, hotMessages)
 
+    Q_PROPERTY(MessageFilterList* lines_filtered READ lines_filtered CONSTANT)
     Q_PROPERTY(QmlObjectList *lines READ lines CONSTANT)
     Q_PROPERTY(QmlObjectList *nicks READ nicks CONSTANT)
     Q_PROPERTY(int normals READ normalsGet NOTIFY nicksChanged)
@@ -90,6 +92,7 @@ public:
 
     QmlObjectList *lines();
     QmlObjectList *nicks();
+    MessageFilterList *lines_filtered();
     Q_INVOKABLE Nick *getNick(pointer_t ptr);
     void addNick(pointer_t ptr, Nick* nick);
     void removeNick(pointer_t ptr);
@@ -116,6 +119,7 @@ public slots:
 private:
     QmlObjectList *m_lines { nullptr };
     QmlObjectList *m_nicks { nullptr };
+    MessageFilterList *m_proxyLinesFiltered { nullptr };
     pointer_t m_ptr;
     bool m_afterInitialFetch { false };
     int m_lastRequestedCount { 0 };

--- a/src/lith.h
+++ b/src/lith.h
@@ -23,6 +23,7 @@
 #include "datamodel.h"
 #include "windowhelper.h"
 #include "util/nicklistfilter.h"
+#include "util/messagelistfilter.h"
 
 #include <QSortFilterProxyModel>
 #include <QPointer>
@@ -141,6 +142,7 @@ private:
     QmlObjectList *m_buffers { nullptr };
     ProxyBufferList *m_proxyBufferList { nullptr };
     NickListFilter *m_selectedBufferNicks { nullptr };
+    MessageFilterList *m_messageBufferList { nullptr };
     int m_selectedBufferIndex { -1 };
 
     QString m_lastNetworkError {};

--- a/src/util/messagelistfilter.cpp
+++ b/src/util/messagelistfilter.cpp
@@ -1,5 +1,5 @@
 // Lith
-// Copyright (C) 2020 Martin Bříza
+// Copyright (C) 2021 Jakub Mach
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -23,9 +23,10 @@ MessageFilterList::MessageFilterList(QObject *parent, QAbstractListModel *parent
 {
     setSourceModel(parentModel);
     setFilterRole(Qt::UserRole);
-    //setDynamicSortFilter(true);
-    //connect(Lith::instance()->settingsGet(), &Settings::showJoinPartQuitMessagesChanged
-
+    connect(Lith::instance()->settingsGet(), &Settings::showJoinPartQuitMessagesChanged, [this]
+    {
+        invalidateFilter();
+    });
 }
 bool MessageFilterList::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const {
     if (!sourceModel())

--- a/src/util/messagelistfilter.cpp
+++ b/src/util/messagelistfilter.cpp
@@ -1,0 +1,45 @@
+// Lith
+// Copyright (C) 2020 Martin Bříza
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+#include "messagelistfilter.h"
+#include "datamodel.h"
+#include "lith.h"
+
+MessageFilterList::MessageFilterList(QObject *parent, QAbstractListModel *parentModel)
+    : QSortFilterProxyModel(parent)
+{
+    setSourceModel(parentModel);
+    setFilterRole(Qt::UserRole);
+    //setDynamicSortFilter(true);
+    //connect(Lith::instance()->settingsGet(), &Settings::showJoinPartQuitMessagesChanged
+
+}
+bool MessageFilterList::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const {
+    if (!sourceModel())
+        return true;
+
+    auto index = sourceModel()->index(source_row, 0, source_parent);
+    auto v = sourceModel()->data(index);
+    auto b = qvariant_cast<BufferLine*>(v);
+
+    if (b && !Lith::instance()->settingsGet()->showJoinPartQuitMessagesGet()) {
+        return !b->isJoinPartQuitMsgGet();
+    }
+    else
+        return b;
+
+    return false;
+}

--- a/src/util/messagelistfilter.h
+++ b/src/util/messagelistfilter.h
@@ -1,0 +1,17 @@
+#ifndef MESSAGELISTFILTER_H
+#define MESSAGELISTFILTER_H
+
+#include "common.h"
+
+#include <QSortFilterProxyModel>
+
+class MessageFilterList : public QSortFilterProxyModel {
+    Q_OBJECT
+    PROPERTY(QString, filterWord)
+public:
+    MessageFilterList(QObject *parent = nullptr, QAbstractListModel *parentModel = nullptr);
+
+    virtual bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
+};
+
+#endif // MESSAGELISTFILTER_H

--- a/src/util/messagelistfilter.h
+++ b/src/util/messagelistfilter.h
@@ -1,3 +1,19 @@
+// Lith
+// Copyright (C) 2021 Jakub Mach
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; If not, see <http://www.gnu.org/licenses/>.
+
 #ifndef MESSAGELISTFILTER_H
 #define MESSAGELISTFILTER_H
 

--- a/ui/ChannelMessage.qml
+++ b/ui/ChannelMessage.qml
@@ -59,7 +59,6 @@ Rectangle {
         spacing: 0
         Text {
             Layout.alignment: Qt.AlignTop
-            visible: lith.settings.timestampFormat.length > 0 && (messageModel.isJoinPartQuitMsg ? settings.showJoinPartQuitMessages : true)
             text: messageModel.date.toLocaleTimeString(Qt.locale(), lith.settings.timestampFormat) + "\u00A0"
             font.pointSize: settings.baseFontSize
             color: disabledPalette.text
@@ -74,7 +73,6 @@ Rectangle {
             color: palette.text
             textFormat: Text.RichText
             renderType: Text.NativeRendering
-            visible: messageModel.isJoinPartQuitMsg ? settings.showJoinPartQuitMessages : true
         }
 
         Text {
@@ -86,7 +84,6 @@ Rectangle {
             font.pointSize: settings.baseFontSize
             textFormat: Text.RichText
             renderType: Text.NativeRendering
-            visible: messageModel.isJoinPartQuitMsg ? settings.showJoinPartQuitMessages : true
             onLinkActivated: {
                 linkHandler.show(link, root)
             }

--- a/ui/ChannelMessageList.qml
+++ b/ui/ChannelMessageList.qml
@@ -48,7 +48,7 @@ ListView {
     verticalLayoutDirection: ListView.BottomToTop
     orientation: Qt.Vertical
     spacing: lith.settings.messageSpacing
-    model: lith.selectedBuffer ? lith.selectedBuffer.lines : null
+    model: lith.selectedBuffer ? lith.selectedBuffer.lines_filtered : null
     delegate: ChannelMessage {
         messageModel: modelData
     }


### PR DESCRIPTION
This fixes an issue with using `visible:` in QML from #101 when users sets a non-zero message spacing in the Settings dialog since the ListView items disappear, but they are still "there", therefore I've replaced it with a QSortFilterProxy in the C++ code. 

Spacing now works properly with the messages not being in the model at all (set to `13` in these screenshots):
**Show joins:**
![mTlu229](https://user-images.githubusercontent.com/5108747/143132307-a67de5e2-f448-444d-adb9-c02836a02cd6.png)

**Hide joins:**
![XpeyV24](https://user-images.githubusercontent.com/5108747/143080622-f6bd610a-738a-478b-b9e2-ab5df36db4bd.png)


