### PR TITLE
Added experimental font family setting on desktop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,21 +45,28 @@ int main(int argc, char *argv[])
 
     QApplication app(argc, argv);
 
+    Lith::instance();
+    Lith::instance()->windowHelperGet()->init();
+
+    auto fontFamilyFromSettings = Lith::instance()->settingsGet()->baseFontFamilyGet();
+
 #if defined(Q_OS_IOS) || defined(Q_OS_MACOS)
     QFont font("Menlo");
 #else
     QFontDatabase fdb;
     fdb.addApplicationFont(":/fonts/Inconsolata-Variable.ttf");
+
     QFont font("Inconsolata");
+    if(fontFamilyFromSettings.length() != 0) // fontFamilyFromSettings could be NULL (unlikely) or empty (very likely)
+    {
+        font = QFont(fontFamilyFromSettings); // if the font doesn't exist, it doesn't matter atm, Qt fallsback to a monospace font on our behalf
+    }
     font.setKerning(false);
     font.setHintingPreference(QFont::PreferNoHinting);
     font.setStyleHint(QFont::Monospace);
 #endif
     app.setFont(font);
     app.setFont(font, "monospace");
-
-    Lith::instance();
-    Lith::instance()->windowHelperGet()->init();
 
     QQmlApplicationEngine engine;
     engine.addImportPath("qrc:///");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,17 +50,19 @@ int main(int argc, char *argv[])
 
     auto fontFamilyFromSettings = Lith::instance()->settingsGet()->baseFontFamilyGet();
 
-#if defined(Q_OS_IOS) || defined(Q_OS_MACOS)
+#if defined(Q_OS_IOS)
     QFont font("Menlo");
 #else
     QFontDatabase fdb;
     fdb.addApplicationFont(":/fonts/Inconsolata-Variable.ttf");
-
+#if defined(Q_OS_MACOS)
+    QFont font("Menlo");
+#else
     QFont font("Inconsolata");
-    if(fontFamilyFromSettings.length() != 0) // fontFamilyFromSettings could be NULL (unlikely) or empty (very likely)
-    {
+#endif
+    if(fontFamilyFromSettings.length() != 0) // fontFamilyFromSettings could be NULL (unlikely) or empty (not so unlikely)
         font = QFont(fontFamilyFromSettings); // if the font doesn't exist, it doesn't matter atm, Qt fallsback to a monospace font on our behalf
-    }
+
     font.setKerning(false);
     font.setHintingPreference(QFont::PreferNoHinting);
     font.setStyleHint(QFont::Monospace);

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,7 +44,11 @@
 class Settings : public QObject {
     Q_OBJECT
     SETTING(int, lastOpenBuffer, -1)
+#if defined(Q_OS_MACOS)
+    SETTING(QString, baseFontFamily, "Menlo")
+#else
     SETTING(QString, baseFontFamily, "Inconsolata")
+#endif
     SETTING(qreal, baseFontSize, 10)
     SETTING(bool, shortenLongUrls, true)
     SETTING(int, shortenLongUrlsThreshold, 50)

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,6 +44,7 @@
 class Settings : public QObject {
     Q_OBJECT
     SETTING(int, lastOpenBuffer, -1)
+    SETTING(QString, baseFontFamily, "Inconsolata")
     SETTING(qreal, baseFontSize, 10)
     SETTING(bool, shortenLongUrls, true)
     SETTING(int, shortenLongUrlsThreshold, 50)

--- a/ui/SettingsInterface.qml
+++ b/ui/SettingsInterface.qml
@@ -17,6 +17,7 @@
 import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.12
+import QtQuick.Dialogs
 
 ScrollView {
     id: root
@@ -44,6 +45,7 @@ ScrollView {
         settings.hotlistShowUnreadCount = hotlistShowUnreadCountCheckbox.checked
         settings.messageSpacing = messageSpacingSpinbox.value
         settings.showJoinPartQuitMessages = showJoinPartQuitMessagesCheckbox.checked
+        settings.baseFontFamily = fontDialog.currentFont.family
     }
     function onRejected() {
         shortenLongUrlsCheckbox.checked = settings.shortenLongUrls
@@ -66,6 +68,19 @@ ScrollView {
         hotlistShowUnreadCountCheckbox.checked = settings.hotlistShowUnreadCount
         messageSpacingSpinbox.value = settings.messageSpacing
         showJoinPartQuitMessagesCheckbox.checked = settings.showJoinPartQuitMessages
+        fontChangeButton.text = settings.baseFontFamily
+        fontChangeButton.font.family = settings.baseFontFamily
+        fontDialog.currentFont.family = settings.baseFontFamily
+    }
+
+    FontDialog {
+        id: fontDialog
+        currentFont.family: settings.baseFontFamily
+        flags: FontDialog.MonospacedFonts
+        onAccepted: {
+            fontChangeButton.text = fontDialog.selectedFont.family
+            fontChangeButton.font.family = fontDialog.selectedFont.family
+        }
     }
 
     ColumnLayout {
@@ -76,10 +91,27 @@ ScrollView {
         GridLayout {
             id: inputBarLayout
             columns: 2
+            //Layout.alignment: Qt.AlignLeft
             Layout.alignment: Qt.AlignHCenter
 
             Label {
+                visible: !mobilePlatform
+                enabled: !mobilePlatform
+                Layout.alignment: Qt.AlignLeft
+                text: "Font family (requires restart)"
+            }
+            Button {
+                enabled: !mobilePlatform
+                visible: !mobilePlatform
+                id: fontChangeButton
+                text: settings.baseFontFamily
+                font: settings.baseFontSize
+                onClicked: fontDialog.open()
                 Layout.alignment: Qt.AlignRight
+            }
+
+            Label {
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Message font size")
             }
             SpinBox {
@@ -87,35 +119,38 @@ ScrollView {
                 value: settings.baseFontSize
                 from: 6
                 to: 32
+                Layout.alignment: Qt.AlignRight
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Timestamp format")
             }
             TextField {
                 id: timestampFormatInput
                 text: lith.settings.timestampFormat
+                Layout.alignment: Qt.AlignRight
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Show join/part/quit messages")
             }
             CheckBox {
                 id: showJoinPartQuitMessagesCheckbox
                 checked: settings.showJoinPartQuitMessages
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Align nick length")
             }
             SpinBox {
                 id: nickCutoffThresholdSpinBox
                 from: -1
                 to: 100
+                Layout.alignment: Qt.AlignRight
                 value: settings.nickCutoffThreshold
                 textFromValue: function(value, locale) {
                     if (value >= 0)
@@ -134,44 +169,46 @@ ScrollView {
             Label {
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                text: qsTr("<b>Color theme</b>")
+                text: qsTr("Color theme")
+                font.bold: true
+                font.capitalization: Font.AllUppercase
                 horizontalAlignment: Text.AlignHCenter
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Force light theme")
             }
             CheckBox {
                 id: forceLightThemeCheckbox
                 checked: settings.forceLightTheme
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
                 onCheckedChanged: {
                     if (checked)
                         forceDarkThemeCheckbox.checked = false
                 }
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Force dark theme")
             }
             CheckBox {
                 id: forceDarkThemeCheckbox
                 checked: settings.forceDarkTheme
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
                 onCheckedChanged: {
                     if (checked)
                         forceLightThemeCheckbox.checked = false
                 }
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Use black in dark theme")
             }
             CheckBox {
                 id: useTrueBlackWithDarkThemeCheckbox
                 checked: settings.useTrueBlackWithDarkTheme
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
 
 
@@ -188,34 +225,35 @@ ScrollView {
                 text: qsTr("Input bar")
                 horizontalAlignment: Text.AlignHCenter
                 font.bold: true
+                font.capitalization: Font.AllUppercase
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Show autocomplete button")
             }
             CheckBox {
                 id: showAutocompleteButtonCheckbox
                 checked: settings.showAutocompleteButton
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Show gallery button")
             }
             CheckBox {
                 id: showGalleryButtonCheckbox
                 checked: settings.showGalleryButton
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Show send button")
             }
             CheckBox {
                 id: showSendButtonCheckbox
                 checked: settings.showSendButton
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
 
             ////////////////////////// HOTLIST
@@ -231,19 +269,20 @@ ScrollView {
                 text: qsTr("Hotlist")
                 horizontalAlignment: Text.AlignHCenter
                 font.bold: true
+                font.capitalization: Font.AllUppercase
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Enable hotlist")
             }
             CheckBox {
                 id: hotlistEnabledCheckbox
                 checked: settings.hotlistEnabled
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 enabled: hotlistEnabledCheckbox.checked
                 text: qsTr("Show unread count")
             }
@@ -251,10 +290,10 @@ ScrollView {
                 id: hotlistShowUnreadCountCheckbox
                 enabled: hotlistEnabledCheckbox.checked
                 checked: settings.hotlistShowUnreadCount
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 enabled: hotlistEnabledCheckbox.checked
                 text: qsTr("Use compact layout")
             }
@@ -262,7 +301,7 @@ ScrollView {
                 id: hotlistCompactCheckbox
                 enabled: hotlistEnabledCheckbox.checked
                 checked: settings.hotlistCompact
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
 
             ////////////////////////// URL HANDLING
@@ -279,19 +318,20 @@ ScrollView {
                 text: qsTr("URL handling")
                 horizontalAlignment: Text.AlignHCenter
                 font.bold: true
+                font.capitalization: Font.AllUppercase
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Shortening Enabled")
             }
             CheckBox {
                 id: shortenLongUrlsCheckbox
                 checked: settings.shortenLongUrls
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Length threshold")
             }
             TextField {
@@ -317,20 +357,21 @@ ScrollView {
                 text: qsTr("Multimedia")
                 horizontalAlignment: Text.AlignHCenter
                 font.bold: true
+                font.capitalization: Font.AllUppercase
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Open links directly")
             }
             CheckBox {
                 id: openLinksDirectlyCheckbox
                 checked: settings.openLinksDirectly
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
                 visible: openLinksDirectlyCheckbox.checked
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Inside Lith (when possible)")
                 color: openLinksDirectlyInBrowserSwitch.checked ? disabledPalette.text : palette.text
             }
@@ -347,22 +388,22 @@ ScrollView {
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Loop videos by default")
             }
             CheckBox {
                 id: loopVideosByDefaultCheckbox
                 checked: settings.showSendButton
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Mute videos by default")
             }
             CheckBox {
                 id: muteVideosByDefaultCheckbox
                 checked: settings.showSendButton
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
 
             ////////////////////////// ADVANCED TWEAKS
@@ -379,16 +420,17 @@ ScrollView {
                 text: qsTr("Advanced tweaks")
                 horizontalAlignment: Text.AlignHCenter
                 font.bold: true
+                font.capitalization: Font.AllUppercase
             }
 
             Label {
-                Layout.alignment: Qt.AlignRight
+                Layout.alignment: Qt.AlignLeft
                 text: qsTr("Message spacing")
             }
             SpinBox {
                 id: messageSpacingSpinbox
                 value: settings.messageSpacing
-                Layout.alignment: Qt.AlignLeft
+                Layout.alignment: Qt.AlignRight
             }
         }
     }

--- a/ui/SettingsNetwork.qml
+++ b/ui/SettingsNetwork.qml
@@ -100,7 +100,7 @@ ScrollView {
                 }
                 Label {
                     text: "(Less secure, not recommended)"
-                    font.pointSize: lith.settings.baseFontSize * 0.75
+                    font.pointSize: lith.settings.baseFontSize * 0.50
                 }
             }
             CheckBox {
@@ -125,7 +125,7 @@ ScrollView {
                 }
                 Label {
                     text: "(More secure, available since WeeChat 2.9)"
-                    font.pointSize: lith.settings.baseFontSize * 0.75
+                    font.pointSize: lith.settings.baseFontSize * 0.50
                 }
             }
             CheckBox {


### PR DESCRIPTION
Font family changing is only visible on non-mobile platforms and tries to use GTK native and macOS native font dialogs, if those are not available, it creates its own "inline" QML FontDialog (which it does for me on Linux and on Windows 10). 

I emphasize the word "experimental" mainly because some fonts may be not-fully visible in the text input once the font size is set too high and also the QML FontDialog's theme (the inline one, when native is not available) is currently fugged by our theme (probably), so those are the two (at least) reasons why I'm calling it experimental.

Also changed the SettingsInterface UI alignment a bit in a way that imho looks better:
**Changed w/ Sans Serif** (ignore the HOTLIST being to the left, already fixed in latest commit)
![image](https://user-images.githubusercontent.com/5108747/143477119-16cd3492-ba3d-4bfb-a44a-120044b8aa50.png)
**Changed w/ Inconsolata**
![image](https://user-images.githubusercontent.com/5108747/143487804-9a17ab33-f56f-4b1f-98b1-0d45084197be.png)

**Original:**
![image](https://user-images.githubusercontent.com/5108747/143477398-3552b6e4-b6e3-4c65-a243-df25d224550c.png)

I have more to come regarding overhauling the settings UI, but I am gonna do that laterrrr(TM)... so here's this for now. No idea what it looks like on mobile, as I don't have means to test it right now (and I am also lazy just like you;))
