### PR TITLE
Fix FileDialog for Qt6 (no longer present in Qt.labs.platform)

### DIFF
--- a/ui/ChannelView.qml
+++ b/ui/ChannelView.qml
@@ -17,7 +17,9 @@
 import QtQuick 2.12
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.4
-import Qt.labs.platform 1.1
+//import Qt.labs.platform 1.1
+import QtQuick.Dialogs 6.2
+import QtCore
 
 import lith 1.0
 
@@ -104,12 +106,14 @@ ColumnLayout {
 
     FileDialog {
         id: fileDialog
-        folder: StandardPaths.standardLocations(StandardPaths.PicturesLocation).slice(-1)[0]
+        fileMode: FileDialog.OpenFile
+        currentFolder: StandardPaths.standardLocations(StandardPaths.PicturesLocation).slice(-1)[0]
         nameFilters: [ "Image files (*.jpg *.jpeg *.png)" ]
+
         onAccepted: {
             //inputField.text += " " + fileUrl
             //imageButton.isBusy = false
-            uploader.upload(file)
+            uploader.upload(fileDialog.selectedFile)
             Qt.inputMethod.hide()
             inputBar.textInput.forceActiveFocus()
         }


### PR DESCRIPTION
Fixed up qt6 bs, tested on ios, linux and macos - works fine on all of these.

Uses an inline QML dialog on Linux when GTK not present (i.e. gnome sesison), uses macOS file browser on macOS, uses Photos/Recents on iOS.

`QtCore` added because of StandardPaths being out of the labs package now.
`QtQuick.Dialogs` added because of FileDialog being out of the labs package now.

Biggest motivation: Fixes app not opening on iOS atm.