### PR TITLE
SettingsInterface: Fix "Disabled" being to converted to zero

### DIFF
--- a/ui/SettingsInterface.qml
+++ b/ui/SettingsInterface.qml
@@ -154,6 +154,11 @@ ScrollView {
                         return Number(value)
                     return qsTr("Disabled")
                 }
+                valueFromText: function(value, locale) {
+                    if (value === qsTr("Disabled"))
+                        return -1
+                    return Number(value)
+                }
             }
 
             ////////////////////////// COLOR THEME


### PR DESCRIPTION
According to the Qt doc, if you override textFromValue, you also need to override valueFromText.

Fixes: #130