### PR TITLE
desktop: settings: Always show vertical scrollbar

### DIFF
--- a/ui/SettingsInterface.qml
+++ b/ui/SettingsInterface.qml
@@ -25,6 +25,7 @@ ScrollView {
     id: root
     clip: true
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical.policy: !window.platform.mobile ? ScrollBar.AlwaysOn : ScrollBar.vertical.policy
 
     function onAccepted() {
         save()

--- a/ui/SettingsNetwork.qml
+++ b/ui/SettingsNetwork.qml
@@ -26,6 +26,7 @@ ScrollView {
     id: root
     clip: true
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical.policy: !window.platform.mobile ? ScrollBar.AlwaysOn : ScrollBar.vertical.policy
 
     property bool networkSettingsChanged: {
         if (passphraseField.text.length > 0)

--- a/ui/SettingsShortcuts.qml
+++ b/ui/SettingsShortcuts.qml
@@ -24,6 +24,7 @@ ScrollView {
     id: root
     clip: true
     ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+    ScrollBar.vertical.policy: !window.platform.mobile ? ScrollBar.AlwaysOn : ScrollBar.vertical.policy
 
     function onAccepted() {
         save()


### PR DESCRIPTION
It's not always obvious, that you can scroll. This is how settings look on my PC:
![image](https://github.com/LithApp/Lith/assets/17759291/d0d07223-01c6-4fc7-b938-4bd7a236e10a)
