### PR TITLE
macOS: Fix rotating in preview while holding Shift

### DIFF
--- a/ui/PreviewPopup.qml
+++ b/ui/PreviewPopup.qml
@@ -278,7 +278,7 @@ Dialog {
             acceptedButtons: Qt.LeftButton | Qt.MiddleButton | Qt.RightButton
             onWheel: (wheel) => {
                 if (wheel.modifiers & Qt.ShiftModifier) {
-                    delegateImage.rotation += wheel.angleDelta.y / 12
+                    delegateImage.rotation += (wheel.inverted ? wheel.angleDelta.x : wheel.angleDelta.y) / 12
                 }
                 else {
                     delegateImage.scale += wheel.angleDelta.y * 0.002


### PR DESCRIPTION
Previously no action happened since wheel.angleDelta.y was always 0 when inverted is true.