### PR TITLE
Fix warning in lambda

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -47,7 +47,7 @@ Settings::Settings(QObject *parent)
         emit readyChanged();
     };
     std::function<void(void)> *testSettingsReady = new std::function<void(void)>();
-    *testSettingsReady = [=](){
+    *testSettingsReady = [this, testSettingsReady, settingsReady](){
         if (m_settings.status() == QSettings::NoError) {
             settingsReady();
             delete testSettingsReady;


### PR DESCRIPTION
The most important fix of all time.
```

/home/unko/repos/qt/Lith/src/settings.cpp: In lambda function:
/home/unko/repos/qt/Lith/src/settings.cpp:50:26: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
   50 |     *testSettingsReady = [=](){
      |                          ^
/home/unko/repos/qt/Lith/src/settings.cpp:50:26: note: add explicit ‘this’ or ‘*this’ capture
```