### PR TITLE
Fix deadlock if DBus notifications service is not registered

### DIFF
--- a/src/lith.cpp
+++ b/src/lith.cpp
@@ -537,7 +537,7 @@ void Lith::_buffer_line_added(const WeeChatProtocol::HData &hda) {
             bool isRegistered = connectionInterface->isServiceRegistered(serviceName);
 
             if (isRegistered) {
-                QDBusInterface notifications(serviceName, "/org/freedesktop/Notifications", "org.freedesktop.Notifications", dbus);
+                QDBusInterface notifications(serviceName, "/org/freedesktop/Notifications", serviceName, dbus);
                 auto reply = notifications.call("Notify", "Lith", 0U, "org.LithApp.Lith", title, line->colorlessTextGet(), QStringList{}, QVariantMap{}, -1);
             } else {
                 static QIcon appIcon(":/icon.png");


### PR DESCRIPTION
Hi, I found out about this thanks to Spotify still having this bug in 2023, so I thought "hmm, how about I try Lith" - when you have no notification daemon running, **the app freezes including the UI, until a notification daemon is available** (or a timeout runs out, which is in the order of minutes IIRC, dont quote me on that). 

Hence why I'm checking if a deamon is registered in dbus first. If it isn't, use the old trayicon notification. (Dunno what to do about the "code duplication" of this part, though).

Tested by killing (and subsequently reopening) the `dunst` daemon I use and then highlighting myself. The fallback worked correctly, as did the Dbus again once `dunst` was running again.  