### PR TITLE
Add an option to disable rotation in PreviewPopup

### DIFF
--- a/modules/Lith/Core/settings.h
+++ b/modules/Lith/Core/settings.h
@@ -106,6 +106,7 @@ class LITHCORE_EXPORT Settings : public QObject {
 
     SETTING(bool, muteVideosByDefault, true)
     SETTING(bool, loopVideosByDefault, true)
+    SETTING(bool, enableRotationInPreview, false)
 
     SETTING(bool, showImageThumbnails, false)
     SETTING(bool, openLinksDirectly, false)

--- a/modules/Lith/UI/PreviewPopup.qml
+++ b/modules/Lith/UI/PreviewPopup.qml
@@ -359,6 +359,7 @@ Dialog {
         }
         PinchHandler {
             target: delegateImage
+            rotationAxis.enabled: Lith.settings.enableRotationInPreview
         }
         TapHandler {
             target: delegateImage

--- a/modules/Lith/UI/SettingsInterface.qml
+++ b/modules/Lith/UI/SettingsInterface.qml
@@ -46,6 +46,7 @@ QQC2.ScrollView {
         Lith.settings.showDateHeaders = showDateHeadersCheckbox.checked
         Lith.settings.muteVideosByDefault = muteVideosByDefaultCheckbox.checked
         Lith.settings.loopVideosByDefault = loopVideosByDefaultCheckbox.checked
+        Lith.settings.enableRotationInPreview = enableRotationInPreviewCheckbox.checked
         Lith.settings.showImageThumbnails = showImageThumbnailsCheckbox.checked
         Lith.settings.openLinksDirectly = openLinksDirectlyCheckbox.checked
         Lith.settings.openLinksDirectlyInBrowser = openLinksDirectlyInBrowserSwitch.checked
@@ -84,6 +85,7 @@ QQC2.ScrollView {
         showDateHeadersCheckbox.checked = Lith.settings.showDateHeaders
         muteVideosByDefaultCheckbox.checked = Lith.settings.muteVideosByDefault
         loopVideosByDefaultCheckbox.checked = Lith.settings.loopVideosByDefault
+        enableRotationInPreviewCheckbox.checked = Lith.settings.enableRotationInPreview
         showImageThumbnailsCheckbox.checked = Lith.settings.showImageThumbnails
         openLinksDirectlyCheckbox.checked = Lith.settings.openLinksDirectly
         openLinksDirectlyInBrowserSwitch.checked = Lith.settings.openLinksDirectlyInBrowser
@@ -602,6 +604,12 @@ QQC2.ScrollView {
             Fields.Boolean {
                 id: loopVideosByDefaultCheckbox
                 summary: qsTr("Loop videos by default")
+                checked: Lith.settings.showSendButton
+            }
+
+            Fields.Boolean {
+                id: enableRotationInPreviewCheckbox
+                summary: qsTr("Enable rotation in preview")
                 checked: Lith.settings.showSendButton
             }
 


### PR DESCRIPTION
Users surely almost always just want to pinch to zoom instead of rotating, so I set the default to false.

Fixes: #183

Tested only on Android.